### PR TITLE
change Dockerfile to multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:1.14.2-alpine3.11
-RUN mkdir app
-ADD . app/
-WORKDIR app
+FROM golang:1.14.2-alpine3.11 as builder
+WORKDIR /app
+COPY . /app
 RUN go build -o main ./cmd/server/main.go
+
+FROM alpine:latest
+WORKDIR app/
+COPY --from=builder /app/main .
 EXPOSE 5000
 CMD ["./main"]
 


### PR DESCRIPTION
Com a mudança do Dockerfile para [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) a imagem gerada reduziu seu tamanho de 438MB para 17.5MB (reduçao de ~95%)